### PR TITLE
Changed builtin_export argument, fixed spelling error in builtin_env

### DIFF
--- a/srcs/builtin/builtin_env.c
+++ b/srcs/builtin/builtin_env.c
@@ -6,7 +6,7 @@
 /*   By: smizuoch <smizuoch@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 11:33:05 by smizuoch          #+#    #+#             */
-/*   Updated: 2023/10/03 14:57:41 by smizuoch         ###   ########.fr       */
+/*   Updated: 2023/10/03 16:00:03 by smizuoch         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,14 +31,14 @@ static bool	check_env(char *env)
 int	builtin_env(char **argv, t_env *env)
 {
 	int			i;
-	char		*anderbar;
+	char		*underbar;
 	t_envnode	*tmp;
 
 	(void)argv;
 	i = 0;
 	tmp = env->head;
-	anderbar = getenv("_");
-	if (!anderbar)
+	underbar = getenv("_");
+	if (!underbar)
 		return (FAILURE);
 	while (tmp)
 	{
@@ -47,7 +47,7 @@ int	builtin_env(char **argv, t_env *env)
 		tmp = tmp->next;
 	}
 	ft_putstr_fd("_=", STDOUT_FILENO);
-	ft_putendl_fd(anderbar, STDOUT_FILENO);
+	ft_putendl_fd(underbar, STDOUT_FILENO);
 	return (SUCCESS);
 }
 

--- a/srcs/builtin/builtin_export.c
+++ b/srcs/builtin/builtin_export.c
@@ -6,76 +6,91 @@
 /*   By: smizuoch <smizuoch@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 11:32:22 by smizuoch          #+#    #+#             */
-/*   Updated: 2023/09/16 17:53:16 by smizuoch         ###   ########.fr       */
+/*   Updated: 2023/10/03 15:59:07 by smizuoch         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/builtin.h"
 
-static void	ft_setenv(char *name, char **env)
+static void	new_envnode(t_env *env, char *name)
 {
-	int		i;
-	char	*tmp;
-	char 	new_env[PATH_MAX];
+	t_envnode	*new;
+	t_envnode	*tmp;
+
+	new = (t_envnode *)malloc(sizeof(t_envnode));
+	if (!new)
+		return ;
+	new->next = NULL;
+	tmp = env->head;
+	while (tmp)
+	{
+		if (tmp->next == NULL)
+			break ;
+		tmp = tmp->next;
+	}
+	new->key = ft_strdup(name);
+	tmp->next = new;
+	new->prev = tmp;
+	if (new->key == NULL)
+		return ;
+}
+
+static void	ft_setenv(char *name, t_env *env)
+{
+	int			i;
+	t_envnode	*new;
+	t_envnode	*tmp;
 
 	i = 0;
-	while (env[i])
+	tmp = env->head;
+	while (name[i] && name[i] != '=')
+		i++;
+	while (tmp)
 	{
-		if (ft_strncmp(env[i], tmp, ft_strlen(tmp)) == 0)
+		if (ft_strncmp(tmp->key, name, i) == 0)
 		{
-			free(env[i]);
-			env[i] = ft_strdup(name);
-			free(tmp);
+			free(tmp->key);
+			tmp->key = NULL;
+			tmp->key = ft_strdup(name);
 			return ;
 		}
-		i++;
+		tmp = tmp->next;
 	}
-	env[i] = ft_strdup(name);
-	free(tmp);
-	return ;
+	new_envnode(env, name);
 }
 
 static bool	env_check_alpha(char *str)
 {
-	int	i;
-
-	i = 0;
-	if (!str)
+	if (!ft_isalpha(str[0]))
 		return (false);
-	while (str[i])
-	{
-		if (ft_isalpha(str[i]) == false)
-			return (false);
-		i++;
-	}
 	return (true);
 }
 
-static int	put_env(char **env)
+static int	put_env(t_env *env)
 {
-	int	i;
+	int			i;
+	t_envnode	*tmp;
 
 	i = 0;
+	tmp = env->head;
 	if (!env)
 		return (FAILURE);
-	while (env[i])
+	while (tmp)
 	{
-		ft_putendl_fd(env[i], STDOUT_FILENO);
-		i++;
+		ft_putendl_fd(tmp->key, STDOUT_FILENO);
+		tmp = tmp->next;
 	}
 	return (SUCCESS);
 }
 
-int	builtin_export(char **argv, char **env)
+int	builtin_export(char **argv, t_env *env)
 {
 	int	i;
-	int	j;
 	int	status;
 
-	i = 0;
-	j = 0;
+	i = 1;
 	status = SUCCESS;
-	if (argv[1] == NULL)
+	if (argv == NULL || argv[1] == NULL)
 		return (put_env(env));
 	while (argv[i])
 	{
@@ -87,9 +102,27 @@ int	builtin_export(char **argv, char **env)
 			status = FAILURE;
 		}
 		else
-		{
 			ft_setenv(argv[i], env);
-		}
+		i++;
 	}
 	return (status);
 }
+
+// int	main(int argc, char **argv)
+// {
+// 	(void)argc;
+// 	t_env	env;
+// 	t_envnode	tmp, tmp2;
+// 	env.head = &tmp;
+// 	tmp.key = malloc(sizeof(char) * 10);
+// 	tmp.key = "OLDPWD=aaa";
+// 	tmp.next = &tmp2;
+// 	tmp2.key = malloc(sizeof(char) * 10);
+// 	tmp2.key = "PWD=bbb";
+// 	tmp2.next = NULL;
+// 	tmp2.prev = &tmp;
+// 	tmp.prev = NULL;
+// 	builtin_export(argv, &env);
+// 	// put_env(&env); 
+// 	return (0);
+// }


### PR DESCRIPTION
コマンドの引数をt_envに変更