### PR TITLE
Fix when env has many arguments

### DIFF
--- a/srcs/builtin/builtin_env.c
+++ b/srcs/builtin/builtin_env.c
@@ -6,7 +6,7 @@
 /*   By: smizuoch <smizuoch@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 11:33:05 by smizuoch          #+#    #+#             */
-/*   Updated: 2023/10/04 15:06:20 by smizuoch         ###   ########.fr       */
+/*   Updated: 2023/10/18 14:41:17 by smizuoch         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,8 +17,6 @@ static bool	check_env(char *env)
 	int	i;
 
 	i = 0;
-	if (!ft_strncmp(env, "_=", 2))
-		return (false);
 	while (env[i])
 	{
 		if (env[i] == '=')
@@ -31,25 +29,24 @@ static bool	check_env(char *env)
 int	builtin_env(char **argv, t_env *env)
 {
 	int			i;
-	char		*underbar;
 	t_envnode	*tmp;
 
 	(void)argv;
 	if (env == NULL || env->head == NULL)
 		return (SUCCESS);
+	if (argv[1] != NULL)
+	{
+		ft_putendl_fd("env: too many arguments", STDERR_FILENO);
+		return (FAILURE);
+	}
 	i = 0;
 	tmp = env->head;
-	underbar = getenv("_");
-	if (!underbar)
-		return (FAILURE);
 	while (tmp)
 	{
 		if (check_env(tmp->key))
 			ft_putendl_fd(tmp->key, STDOUT_FILENO);
 		tmp = tmp->next;
 	}
-	ft_putstr_fd("_=", STDOUT_FILENO);
-	ft_putendl_fd(underbar, STDOUT_FILENO);
 	return (SUCCESS);
 }
 


### PR DESCRIPTION
env aやenv -などを受け付けないように修正、また_=を変更しないように編集。