### PR TITLE
Ktomoya

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -27,6 +27,7 @@ void	puterr_exit(const char *input, const char *msg, int exit_status);
 void	putsyserr_exit(const char *syscall_name);
 bool	is_builtin(char *cmd);
 bool	is_directory(char *path);
+bool    directory_exists(char *path);
 void	execute_abspath(char *const argv[], t_env *env);
 char	*get_path_value(char *const argv[], t_env *env);
 void	search_path(char *const argv[], t_env *env);

--- a/includes/parser.h
+++ b/includes/parser.h
@@ -34,6 +34,7 @@ typedef struct s_node
 	const char		*str;
 	size_t 			len;
 	char			*expand;
+    int             expand_flag;
 }	t_node;
 
 // nodeの構造体にcomanndの構造体を追加する

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -131,11 +131,6 @@ int	execute_redirect(t_node *ast, int *fd, char *tmp_file)
 			restore_fd(fd[0], fd[1]);
 		if (redir->kind == NODE_LESS)
 		{
-            if (!directory_exists(file_here))
-            {
-                free(file_here);
-                return (ERROR);
-            }
 			fd = redirect_input(file_here, fd);
 			if (!fd)
 			{
@@ -145,12 +140,7 @@ int	execute_redirect(t_node *ast, int *fd, char *tmp_file)
 		}
 		else if (redir->kind == NODE_GREAT)
 		{
-            if (!directory_exists(file_here))
-            {
-                free(file_here);
-                return (ERROR);
-            }
-			fd = redirect_output(file_here, fd);
+            fd = redirect_output(file_here, fd);
 			if (!fd)
 			{
 				free(file_here);
@@ -159,11 +149,6 @@ int	execute_redirect(t_node *ast, int *fd, char *tmp_file)
 		}
 		else if (redir->kind == NODE_DGREAT)
 		{
-            if (!directory_exists(file_here))
-            {
-                free(file_here);
-                return (ERROR);
-            }
 			fd = redirect_append(file_here, fd);
 			if (!fd)
 			{

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -131,6 +131,11 @@ int	execute_redirect(t_node *ast, int *fd, char *tmp_file)
 			restore_fd(fd[0], fd[1]);
 		if (redir->kind == NODE_LESS)
 		{
+            if (!directory_exists(file_here))
+            {
+                free(file_here);
+                return (ERROR);
+            }
 			fd = redirect_input(file_here, fd);
 			if (!fd)
 			{
@@ -140,6 +145,11 @@ int	execute_redirect(t_node *ast, int *fd, char *tmp_file)
 		}
 		else if (redir->kind == NODE_GREAT)
 		{
+            if (!directory_exists(file_here))
+            {
+                free(file_here);
+                return (ERROR);
+            }
 			fd = redirect_output(file_here, fd);
 			if (!fd)
 			{
@@ -149,6 +159,11 @@ int	execute_redirect(t_node *ast, int *fd, char *tmp_file)
 		}
 		else if (redir->kind == NODE_DGREAT)
 		{
+            if (!directory_exists(file_here))
+            {
+                free(file_here);
+                return (ERROR);
+            }
 			fd = redirect_append(file_here, fd);
 			if (!fd)
 			{

--- a/srcs/execute/execute_bool.c
+++ b/srcs/execute/execute_bool.c
@@ -35,3 +35,27 @@ bool	is_directory(char *path)
 		return (true);
 	return (false);
 }
+
+bool    directory_exists(char *path)
+{
+    struct stat buf;
+    char        *endp;
+    char        *dir;
+
+    endp = path;
+    endp = ft_strrchr(endp, '/');
+    // スラッシュがなければディレクトリではない。カレントディレクトリなので存在する。
+    if (!endp)
+        return (true);
+    dir = ft_substr(path, 0, endp - path);
+    if (stat(dir, &buf) == ERROR)
+    {
+        puterr(path, strerror(errno)); // Todo: exitしないputsyserr関数を作る
+        free(dir);
+        return (false);
+    }
+    free(dir);
+    if (S_ISDIR(buf.st_mode))
+        return (true);
+    return (false);
+}

--- a/srcs/execute/execute_bool.c
+++ b/srcs/execute/execute_bool.c
@@ -30,32 +30,8 @@ bool	is_directory(char *path)
 	struct stat	buf;
 
 	if (stat(path, &buf) == ERROR)
-		putsyserr_exit("stat");
+		return (false);
 	if (S_ISDIR(buf.st_mode))
 		return (true);
 	return (false);
-}
-
-bool    directory_exists(char *path)
-{
-    struct stat buf;
-    char        *endp;
-    char        *dir;
-
-    endp = path;
-    endp = ft_strrchr(endp, '/');
-    // スラッシュがなければディレクトリではない。カレントディレクトリなので存在する。
-    if (!endp)
-        return (true);
-    dir = ft_substr(path, 0, endp - path);
-    if (stat(dir, &buf) == ERROR)
-    {
-        puterr(path, strerror(errno)); // Todo: exitしないputsyserr関数を作る
-        free(dir);
-        return (false);
-    }
-    free(dir);
-    if (S_ISDIR(buf.st_mode))
-        return (true);
-    return (false);
 }

--- a/srcs/expansion/expand.c
+++ b/srcs/expansion/expand.c
@@ -295,6 +295,8 @@ char	*expand_node(const char *line, t_env *env)
 {
 	char	*expanded;
 	size_t	len = count_len(line, env);
+    if (len == 0)
+        return (NULL);
 	// printf("len: %zu\n", len);
 	expanded = ft_calloc(len + 1, sizeof(char));
 	copy_expand(expanded, line, env);
@@ -316,6 +318,8 @@ t_node	*expand(t_node *ast, t_env *env)
 	{
 		unexpanded = ft_substr(ast->str, 0, ast->len);
 		ast->expand = expand_node(unexpanded, env);
+        if (!ast->expand && (ft_strchr(unexpanded, '$') || ft_strchr(unexpanded, '\'') || ft_strchr(unexpanded, '\"')))
+            ast->expand_flag = FAILURE;
 		// printf("ast->expand: %s\n", ast->expand);
 		free(unexpanded);
 		expand(ast->right, env);
@@ -324,6 +328,8 @@ t_node	*expand(t_node *ast, t_env *env)
 	{
 		unexpanded = ft_substr(ast->str, 0, ast->len);
 		ast->expand = expand_node(unexpanded, env);
+        if (!ast->expand && (ft_strchr(unexpanded, '$') || ft_strchr(unexpanded, '\'') || ft_strchr(unexpanded, '\"')))
+            ast->expand_flag = FAILURE;
 		free(unexpanded);
 		expand(ast->right, env);
 	}

--- a/srcs/parser/grammar.c
+++ b/srcs/parser/grammar.c
@@ -33,11 +33,6 @@
 
 void	put_syntax_error(t_token *tok)
 {
-	char	input[100000];
-
-	ft_memset(input, 0, 100000);
-	if (tok && tok->type == TYPE_GENERAL)
-		ft_memcpy(input, tok->str, tok->len);
 	ft_putstr_fd("syntax error near unexpected token `", STDERR_FILENO);
 	if (tok && tok->type == TYPE_PIPE)
 		ft_putstr_fd("|", STDERR_FILENO);
@@ -50,7 +45,7 @@ void	put_syntax_error(t_token *tok)
 	else if (tok && tok->type == TYPE_DLESS)
 		ft_putstr_fd("<<", STDERR_FILENO);
 	else if (tok && tok->type == TYPE_GENERAL)
-		ft_putstr_fd(input, STDERR_FILENO);
+        write(STDERR_FILENO, tok->str, tok->len);
 	else if (tok && tok->type == TYPE_EOF)
 		ft_putstr_fd("newline", STDERR_FILENO);
 	ft_putendl_fd("'", STDERR_FILENO);

--- a/srcs/parser/grammar.c
+++ b/srcs/parser/grammar.c
@@ -14,22 +14,8 @@
 #include "../../includes/minishell.h"
 
 /*
- * 目標: cmd_suffixの文法を実装する
- * 準目標:
+ * 目標: cmd_prefixの文法を実装する
  */
-
-/*
- * リダイレクトの文法
- * コマンド名　引数1 引数2 ... 引数n <リダイレクト1> <リダイレクト2> ... <リダイレクトn>
- */
-
-//void	*syntax_error_null(const char *token)
-//{
-//	ft_putstr_fd("syntax error near unexpected token `", STDERR_FILENO);
-//	ft_putstr_fd(token, STDERR_FILENO);
-//	ft_putendl_fd("'", STDERR_FILENO);
-//	return (NULL);
-//}
 
 void	put_syntax_error(t_token *tok)
 {
@@ -58,101 +44,75 @@ void	*syntax_error_null(t_token *tok)
 }
 
 /*
- * pipeline = command ('|' command)*
+ * command_line = command ('|' command)*
  */
-t_node	*command_line(t_token *tok, int *flag)
-{
-	t_node	*node;
-
-	if (!expect(TYPE_GENERAL, tok))
-	{
-		if (expect_next(TYPE_GENERAL, tok))
-			return (syntax_error_null(tok->cur));
-		else
-			return (syntax_error_null(tok->cur->next));
-	}
-	node = command(tok, flag);
-	if (!node)
-		return (NULL);
-	while (1)
-	{
-		if (consume(TYPE_PIPE, tok))
-		{
-			if (expect(TYPE_GENERAL, tok))
-			{
-				node = new_branch(NODE_PIPE, node, command(tok, flag));
-				if (!node)
-				{
-					*flag = ERROR;
-					return (NULL);
-				}
-			}
-			else
-			{
-				*flag = ERROR;
-				put_syntax_error(tok->cur);
-				return (node);
-			}
-		}
-		else
-			return (node);
-	}
-}
-
-/*
- * simple_command ::= cmd_name word_list?
- * word_list ::= word+
- */
-//t_node	*command(t_token *tok)
+//t_node	*command_line(t_token *tok, int *flag)
 //{
-//	t_node	*cmd;
-//	t_token	*cur;
 //	t_node	*node;
 //
-//	cmd = NULL;
-//	cur = tok->cur;
-//	while (cur->type != TYPE_EOF && cur->type != TYPE_PIPE)
+//	if (!expect(TYPE_GENERAL, tok))
 //	{
-//		node = new_node(NODE_ARGUMENT);
-//		if (!node)
-//		{
-//			// Todo: 構文木をfreeする関数を作る
-//			return (NULL);
-//		}
-//		node->word = ft_substr(cur->str, 0, cur->len);
-//		if (node->word == NULL)
-//		{
-//			// Todo: freeする
-//			return (NULL);
-//		}
-//		lstadd_back_node(&cmd, node);
-//		cur = cur->next;
+//		if (expect_next(TYPE_GENERAL, tok))
+//			return (syntax_error_null(tok->cur));
+//		else
+//			return (syntax_error_null(tok->cur->next));
 //	}
-//	tok->cur = cur;
-//	return (cmd);
-//}
-
-/* command ::= cmd_name cmd_suffix? */
-/* cmd_name ::= WORD */
-//t_node	*command(t_token *tok)
-//{
-//	t_token	*cur;
-//	t_node	*cmd;
-//	t_node	*node;
-//
-//	cur = tok->cur;
-//	cmd = new_node(NODE_COMMAND);
-//	node->word = ft_substr(cur->str, 0, cur->len);
+//	node = command(tok, flag);
+//	if (!node)
+//		return (NULL);
 //	while (1)
 //	{
-//		if (cur->type == TYPE_PIPE
-//			|| cur->type == TYPE_EOF)
-//			break ;
+//		if (consume(TYPE_PIPE, tok))
+//		{
+//			if (expect(TYPE_GENERAL, tok))
+//			{
+//				node = new_branch(NODE_PIPE, node, command(tok, flag));
+//				if (!node)
+//				{
+//					*flag = ERROR;
+//					return (NULL);
+//				}
+//			}
+//			else
+//			{
+//				*flag = ERROR;
+//				put_syntax_error(tok->cur);
+//				return (node);
+//			}
+//		}
 //		else
-//			node = cmd_suffix
+//			return (node);
 //	}
-//	return (node);
 //}
+
+t_node	*command_line(t_token *tok, int *flag)
+{
+    t_node  *node;
+
+    node = command(tok, flag);
+    if (!node)
+        return (NULL);
+    while (1)
+    {
+        if (consume(TYPE_PIPE, tok))
+        {
+            if (expect(TYPE_EOF, tok) || expect(TYPE_PIPE, tok))
+            {
+                *flag = ERROR;
+                put_syntax_error(tok->cur);
+                return (node);
+            }
+            node = new_branch(NODE_PIPE, node, command(tok, flag));
+            if (!node)
+            {
+                *flag = ERROR;
+                return (NULL);
+            }
+        }
+        else
+            return (node);
+    }
+}
 
 /* cmd_suffix ::= (io_redirect | WORD)+ */
 //t_node	*cmd_suffix(t_token *tok)
@@ -185,21 +145,52 @@ t_node	*command_line(t_token *tok, int *flag)
 //	return (suffix);
 //}
 
-/* command ::= cmd_args io_redirects */
-t_node	*command(t_token *tok, int *flag)
+/*
+ * command ::= cmd_name cmd_suffix?
+ *           | cmd_prefix (cmd_word cmd_suffix?)?
+ */
+t_node  *command(t_token *tok, int *flag)
 {
-	t_node	*cmd;
-	t_node	*redirects;
+    t_node  *list;
+    t_node  *node;
 
-	if (*flag == ERROR)
-		return (NULL);
-	cmd = cmd_args(tok, flag);
-	if (!cmd)
-		return (NULL);
-	redirects = io_redirects(tok, flag);
-	lstadd_back_node(&cmd, redirects);
-	return (cmd);
+    if (expect(TYPE_PIPE, tok) || expect(TYPE_EOF, tok))
+    {
+        *flag = ERROR;
+        return (syntax_error_null(tok->cur));
+    }
+    else if (expect(TYPE_GENERAL, tok))
+        list = cmd_arg(tok, flag);
+    else
+        list = io_redirect(tok, flag);
+    while (!expect(TYPE_EOF, tok) && !expect(TYPE_PIPE, tok))
+    {
+        if (expect(TYPE_GENERAL, tok))
+            node = cmd_arg(tok, flag);
+        else
+            node = io_redirect(tok, flag);
+        if (!node)
+            break ;
+        lstadd_back_node(&list, node);
+    }
+    return (list);
 }
+
+/* command ::= cmd_args io_redirects */
+//t_node	*command(t_token *tok, int *flag)
+//{
+//	t_node	*cmd;
+//	t_node	*redirects;
+//
+//	if (*flag == ERROR)
+//		return (NULL);
+//	cmd = cmd_args(tok, flag);
+//	if (!cmd)
+//		return (NULL);
+//	redirects = io_redirects(tok, flag);
+//	lstadd_back_node(&cmd, redirects);
+//	return (cmd);
+//}
 
 /* cmd_args ::= cmd_arg cmd_args* */
 t_node	*cmd_args(t_token *tok, int *flag)
@@ -297,19 +288,31 @@ t_node	*io_file(t_token *tok, int *flag)
 		*flag = ERROR;
 		return (NULL);
 	}
-	if (expect(TYPE_GENERAL, tok))
-	{
-		if (expect_next(TYPE_GENERAL, tok))
-		{
-			*flag = ERROR;
-			free(node);
-			return (syntax_error_null(tok->cur->next));
-		}
-		set_node_value(node, tok->cur->str, tok->cur->len);
-		if (consume(TYPE_GENERAL, tok))
-			return (node);
-	}
-	else
+//	if (expect(TYPE_GENERAL, tok))
+//	{
+//		if (expect_next(TYPE_GENERAL, tok))
+//		{
+//			*flag = ERROR;
+//			free(node);
+//			return (syntax_error_null(tok->cur->next));
+//		}
+//		set_node_value(node, tok->cur->str, tok->cur->len);
+//		if (consume(TYPE_GENERAL, tok))
+//			return (node);
+//	}
+//	else
+//	{
+//		*flag = ERROR;
+//		free(node);
+//		return (syntax_error_null(tok->cur));
+//	}
+    if (expect(TYPE_GENERAL, tok))
+    {
+        set_node_value(node, tok->cur->str, tok->cur->len);
+        if (consume(TYPE_GENERAL, tok))
+            return (node);
+    }
+    else
 	{
 		*flag = ERROR;
 		free(node);
@@ -324,27 +327,40 @@ t_node	*io_here(t_token *tok, int *flag)
 	t_node	*node;
 
 	node = NULL;
-	if (expect(TYPE_GENERAL, tok))
-	{
-		if (expect_next(TYPE_GENERAL, tok))
-		{
-			*flag = ERROR;
-			return (syntax_error_null(tok->cur->next));
-		}
-		node = new_node(NODE_DLESS);
-		if (!node)
-		{
-			*flag = ERROR;
-			return (NULL);
-		}
-		set_node_value(node, tok->cur->str, tok->cur->len);
-		if (consume(TYPE_GENERAL, tok))
-			return (node);
-	}
-	else
-	{
-		*flag = ERROR;
-		return (syntax_error_null(tok->cur));
-	}
+//	if (expect(TYPE_GENERAL, tok))
+//	{
+//		if (expect_next(TYPE_GENERAL, tok))
+//		{
+//			*flag = ERROR;
+//			return (syntax_error_null(tok->cur->next));
+//		}
+//		node = new_node(NODE_DLESS);
+//		if (!node)
+//		{
+//			*flag = ERROR;
+//			return (NULL);
+//		}
+//		set_node_value(node, tok->cur->str, tok->cur->len);
+//		if (consume(TYPE_GENERAL, tok))
+//			return (node);
+//	}
+//	else
+//	{
+//		*flag = ERROR;
+//		return (syntax_error_null(tok->cur));
+//	}
+    if (!expect(TYPE_GENERAL, tok))
+    {
+        *flag = ERROR;
+        return (syntax_error_null(tok->cur));
+    }
+    node = new_node(NODE_DLESS);
+    if (!node)
+    {
+        *flag = ERROR;
+        return (NULL);
+    }
+    set_node_value(node, tok->cur->str, tok->cur->len);
+    consume(TYPE_GENERAL, tok);
 	return (node);
 }

--- a/srcs/print.c
+++ b/srcs/print.c
@@ -13,6 +13,66 @@
 #include "../includes/minishell.h"
 #include "../includes/parser.h"
 
+void    print_command(t_node *node, int depth)
+{
+    char	word[100];
+    t_node  *cur = node;
+    int  i = 0;
+    int     flag = 0;
+
+    if (cur == NULL || cur->kind == TYPE_EOF)
+        return ;
+    while (i < depth)
+    {
+        printf("  ");
+        i++;
+    }
+    printf("[%d]args : ", depth);
+    while (cur && (cur->kind == NODE_ARGUMENT || cur->kind == NODE_LESS || cur->kind == NODE_GREAT || cur->kind == NODE_DGREAT || cur->kind == NODE_DLESS))
+    {
+        if (cur->kind == NODE_ARGUMENT)
+        {
+            ft_memset(word, 0, 100);
+            if (cur->expand)
+                ft_memcpy(word, cur->expand, ft_strlen(cur->expand));
+            else
+                ft_memcpy(word, cur->str, cur->len);
+            printf("%s", word);
+            if (cur->right && cur->right->kind == NODE_ARGUMENT)
+                printf(", ");
+        }
+        else if (cur->kind == NODE_LESS || cur->kind == NODE_GREAT || cur->kind == NODE_DGREAT || cur->kind == NODE_DLESS)
+            flag = 1;
+        cur = cur->right;
+
+    }
+    if (flag != 1)
+        return ;
+    printf(" ");
+    printf("redirect: ");
+    cur = node;
+    while (cur && (cur->kind == NODE_ARGUMENT || cur->kind == NODE_LESS || cur->kind == NODE_GREAT || cur->kind == NODE_DGREAT || cur->kind == NODE_DLESS))
+    {
+        if (cur->kind == NODE_LESS || cur->kind == NODE_GREAT || cur->kind == NODE_DGREAT || cur->kind == NODE_DLESS)
+            ft_memset(word, 0, 100);
+        if (cur->expand)
+            ft_memcpy(word, cur->expand, ft_strlen(cur->expand));
+        else
+            ft_memcpy(word, cur->str, cur->len);
+        if (cur->kind == NODE_LESS)
+		    printf("<%s", word);
+        else if (cur->kind == NODE_GREAT)
+            printf(">%s", word);
+        else if (cur->kind == NODE_DGREAT)
+            printf(">>%s", word);
+        else if (cur->kind == NODE_DLESS)
+            printf("<<%s", word);
+        if (cur->right && (cur->kind == NODE_LESS || cur->kind == NODE_GREAT || cur->kind == NODE_DGREAT || cur->kind == NODE_DLESS))
+            printf(", ");
+        cur = cur->right;
+    }
+}
+
 void	print_node_tree(t_node *node, int depth)
 {
 	int		i;
@@ -31,13 +91,11 @@ void	print_node_tree(t_node *node, int depth)
 		printf("  ");
 		i++;
 	}
-	if (node->kind == NODE_ARGUMENT)
+	if (node->kind == NODE_ARGUMENT || node->kind == NODE_LESS || node->kind == NODE_GREAT || node->kind == NODE_DGREAT || node->kind == NODE_DLESS)
 	{
-		if (node->expand)
-			printf("[%d]command: %s, args: ", depth, word);
-		else
-			printf("[%d]command: %s, args: ", depth, word);
-		print_argument_list(node->right, depth + 1);
+//		printf("[%d]command: %s, args: ", depth, word);
+//		print_argument_list(node->right, depth + 1);
+        print_command(node, depth);
 		printf("\n");
 	}
 	else if (node->kind == NODE_PIPE)
@@ -46,29 +104,29 @@ void	print_node_tree(t_node *node, int depth)
 		print_node_tree(node->left, depth + 1);
 		print_node_tree(node->right, depth + 1);
 	}
-	else if (node->kind == NODE_LESS)
-	{
-		printf("[%d]<, filename: %s\n", depth, word);
-		print_node_tree(node->left, depth + 1);
-		print_node_tree(node->right, depth + 1);
-	}
-	else if (node->kind == NODE_GREAT)
-	{
-		printf("[%d]>, filename: %s\n", depth, word);
-		print_node_tree(node->left, depth + 1);
-		print_node_tree(node->right, depth + 1);
-	}
-	else if (node->kind == NODE_DGREAT)
-	{
-		printf("[%d]>>, filename: %s\n", depth, word);
-		print_node_tree(node->left, depth + 1);
-		print_node_tree(node->right, depth + 1);
-	}
-	else if (node->kind == NODE_DLESS)
-	{
-		print_redirect_list(node, depth);
-		printf("\n");
-	}
+//	else if (node->kind == NODE_LESS)
+//	{
+//		printf("[%d]<, filename: %s\n", depth, word);
+//		print_node_tree(node->left, depth + 1);
+//		print_node_tree(node->right, depth + 1);
+//	}
+//	else if (node->kind == NODE_GREAT)
+//	{
+//		printf("[%d]>, filename: %s\n", depth, word);
+//		print_node_tree(node->left, depth + 1);
+//		print_node_tree(node->right, depth + 1);
+//	}
+//	else if (node->kind == NODE_DGREAT)
+//	{
+//		printf("[%d]>>, filename: %s\n", depth, word);
+//		print_node_tree(node->left, depth + 1);
+//		print_node_tree(node->right, depth + 1);
+//	}
+//	else if (node->kind == NODE_DLESS)
+//	{
+//		print_redirect_list(node, depth);
+//		printf("\n");
+//	}
 }
 
 //void print_node(t_node *node, int depth) {

--- a/srcs/redirect/redirect.c
+++ b/srcs/redirect/redirect.c
@@ -70,6 +70,18 @@ void	restore_fd(int save_fd, int stdfd)
 /* > file */
 int	*redirect_output(const char *file, int *fd)
 {
+    if (is_directory((char *)file))
+    {
+        puterr(file, strerror(EISDIR));
+        free(fd);
+        return (NULL);
+    }
+    if (access(file, W_OK) == ERROR)
+    {
+        puterr(file, strerror(errno));
+        free(fd);
+        return (NULL);
+    }
 	fd[0] = dup(STDOUT_FILENO);
 	close(STDOUT_FILENO);
 	fd[1] = open(file, O_WRONLY|O_CREAT|O_TRUNC, 0644);
@@ -89,6 +101,18 @@ int	*redirect_output(const char *file, int *fd)
 
 int	*redirect_append(const char *file, int *fd)
 {
+    if (is_directory((char *)file))
+    {
+        puterr(file, strerror(EISDIR));
+        free(fd);
+        return (NULL);
+    }
+    if (access(file, W_OK) == ERROR)
+    {
+        puterr(file, strerror(errno));
+        free(fd);
+        return (NULL);
+    }
 	fd[0] = dup(STDOUT_FILENO);
 	close(STDOUT_FILENO);
 	fd[1] = open(file, O_WRONLY|O_CREAT|O_APPEND, 0644);
@@ -108,6 +132,18 @@ int	*redirect_append(const char *file, int *fd)
 //}
 int	*redirect_input(const char *file, int *fd)
 {
+    if (is_directory((char *)file))
+    {
+        puterr(file, strerror(EISDIR));
+        free(fd);
+        return (NULL);
+    }
+    if (access(file, R_OK) == ERROR)
+    {
+        puterr(file, strerror(errno));
+        free(fd);
+        return (NULL);
+    }
 	fd[0] = dup(STDIN_FILENO);
 	close(STDIN_FILENO);
 	fd[1] = open(file, O_RDONLY);

--- a/srcs/redirect/redirect.c
+++ b/srcs/redirect/redirect.c
@@ -70,12 +70,6 @@ void	restore_fd(int save_fd, int stdfd)
 /* > file */
 int	*redirect_output(const char *file, int *fd)
 {
-	if (access(file, R_OK) == ERROR)
-	{
-		free(fd);
-		puterr(file, strerror(errno));
-		return (NULL);
-	}
 	fd[0] = dup(STDOUT_FILENO);
 	close(STDOUT_FILENO);
 	fd[1] = open(file, O_WRONLY|O_CREAT|O_TRUNC, 0644);
@@ -95,12 +89,6 @@ int	*redirect_output(const char *file, int *fd)
 
 int	*redirect_append(const char *file, int *fd)
 {
-	if (access(file, R_OK) == ERROR)
-	{
-		free(fd);
-		puterr(file, strerror(errno));
-		return (NULL);
-	}
 	fd[0] = dup(STDOUT_FILENO);
 	close(STDOUT_FILENO);
 	fd[1] = open(file, O_WRONLY|O_CREAT|O_APPEND, 0644);
@@ -120,12 +108,6 @@ int	*redirect_append(const char *file, int *fd)
 //}
 int	*redirect_input(const char *file, int *fd)
 {
-	if (access(file, F_OK) == ERROR)
-	{
-		free(fd);
-		puterr(file, strerror(errno));
-		return (NULL);
-	}
 	fd[0] = dup(STDIN_FILENO);
 	close(STDIN_FILENO);
 	fd[1] = open(file, O_RDONLY);

--- a/srcs/redirect/redirect.c
+++ b/srcs/redirect/redirect.c
@@ -76,7 +76,7 @@ int	*redirect_output(const char *file, int *fd)
         free(fd);
         return (NULL);
     }
-    if (access(file, W_OK) == ERROR)
+    if (access(file, W_OK) == ERROR && errno != ENOENT)
     {
         puterr(file, strerror(errno));
         free(fd);
@@ -107,7 +107,7 @@ int	*redirect_append(const char *file, int *fd)
         free(fd);
         return (NULL);
     }
-    if (access(file, W_OK) == ERROR)
+    if (access(file, W_OK) == ERROR && errno != ENOENT)
     {
         puterr(file, strerror(errno));
         free(fd);


### PR DESCRIPTION
リダイレクトの権限チェック追加、および変数展開を失敗したときにリダイレクト専用のエラーメッセージを追加、パーサーの文法を変更しました。
```
minishell$ > file echo aaaaaa bbbbbbb >> file cccccc
minishell$ cat file
aaaaaa bbbbbbb cccccc
```