### PR TITLE
add: handle malloc error

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/19 19:00:33 by kudoutomoya       #+#    #+#             */
-/*   Updated: 2023/11/18 10:36:11 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/20 08:49:13 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,5 +39,6 @@ void	search_path(char *const argv[], t_env *env);
 char	**make_argument_list(t_node *ast);
 void	restore_stdfd(int fd[4]);
 void	ft_unlink(char *file);
+void	free_matrix(char **matrix);
 
 #endif

--- a/includes/execute.h
+++ b/includes/execute.h
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/19 19:00:33 by kudoutomoya       #+#    #+#             */
-/*   Updated: 2023/11/20 08:49:13 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/20 09:45:34 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,7 +36,7 @@ bool	directory_exists(char *path);
 void	execute_abspath(char *const argv[], t_env *env);
 char	*get_path_value(char *const argv[], t_env *env);
 void	search_path(char *const argv[], t_env *env);
-char	**make_argument_list(t_node *ast);
+char	**make_argument_list(t_node *ast, t_env *env);
 void	restore_stdfd(int fd[4]);
 void	ft_unlink(char *file);
 void	free_matrix(char **matrix);

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/19 19:03:27 by kudoutomoya       #+#    #+#             */
-/*   Updated: 2023/11/20 08:46:10 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/20 09:14:32 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -87,7 +87,7 @@ int	execute_command(t_node *ast, t_env *env)
 	{
 		env->exit_status = 1;
 		restore_stdfd(fd);
-		return (ERROR);
+		return (1);
 	}
 	args = make_argument_list(ast);
 	if (args)

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/19 19:03:27 by kudoutomoya       #+#    #+#             */
-/*   Updated: 2023/11/18 10:42:32 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/20 08:46:10 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,19 +15,6 @@
 #include "../../includes/redirect.h"
 #include "../../includes/minishell.h"
 #include "../../includes/pipe.h"
-
-void	free_matrix(char **matrix)
-{
-	size_t	i;
-
-	i = 0;
-	while (matrix[i])
-	{
-		free(matrix[i]);
-		i++;
-	}
-	free(matrix);
-}
 
 size_t	count_args(t_node *ast)
 {
@@ -43,6 +30,21 @@ size_t	count_args(t_node *ast)
 	return (count);
 }
 
+int	get_arg(char **dst, t_node *node, char **head)
+{
+	(void)head;
+	if (node->expand)
+		*dst = ft_substr(node->expand, 0, ft_strlen(node->expand));
+	else
+		*dst = ft_substr(node->str, 0, node->len);
+	if (!*dst)
+	{
+		free_matrix(head);
+		return (perror_retint("malloc", ERROR));
+	}
+	return (SUCCESS);
+}
+
 char	**make_argument_list(t_node *ast)
 {
 	char	**args;
@@ -52,7 +54,9 @@ char	**make_argument_list(t_node *ast)
 	count = count_args(ast);
 	if (count == 0)
 		return (NULL);
-	args = (char **)ft_calloc(count + 1, sizeof(char *));
+	args = ft_calloc(count + 1, sizeof(char *));
+	if (!args)
+		return (perror_null("malloc"));
 	i = 0;
 	while (i < count)
 	{
@@ -61,10 +65,8 @@ char	**make_argument_list(t_node *ast)
 			ast = ast->right;
 			continue ;
 		}
-		else if (ast->expand)
-			args[i] = ft_substr(ast->expand, 0, ft_strlen(ast->expand));
-		else
-			args[i] = ft_substr(ast->str, 0, ast->len);
+		if (get_arg(&args[i], ast, args) == ERROR)
+			return (NULL);
 		ast = ast->right;
 		i++;
 	}

--- a/srcs/execute/execute_redirect.c
+++ b/srcs/execute/execute_redirect.c
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/18 10:32:45 by ktomoya           #+#    #+#             */
-/*   Updated: 2023/11/18 11:48:02 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/20 12:48:22 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,8 @@ int	parse_file(t_node *node, char **file_here)
 int	execute_heredocument(char *eof, int fd[4], char **tmp_file)
 {
 	ft_unlink(*tmp_file);
+	if (fd[0] != fd[1])
+		restore_fd(fd[0], fd[1]);
 	*tmp_file = here_document(eof);
 	if (g_signal == 2)
 		return (ERROR);

--- a/srcs/execute/execute_utils.c
+++ b/srcs/execute/execute_utils.c
@@ -6,11 +6,24 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/18 10:23:53 by ktomoya           #+#    #+#             */
-/*   Updated: 2023/11/18 10:25:02 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/20 08:48:30 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/execute.h"
+
+void	free_matrix(char **matrix)
+{
+	size_t	i;
+
+	i = 0;
+	while (matrix[i])
+	{
+		free(matrix[i]);
+		i++;
+	}
+	free(matrix);
+}
 
 void	restore_stdfd(int fd[4])
 {

--- a/srcs/execute/launch_command.c
+++ b/srcs/execute/launch_command.c
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/18 10:38:22 by ktomoya           #+#    #+#             */
-/*   Updated: 2023/11/18 10:40:18 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/20 14:52:49 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ static int	wait_child(pid_t pid, t_env *env)
 		write(1, "\n", 1);
 		env->exit_status = WTERMSIG(status) + 128;
 	}
-	return (status);
+	return (env->exit_status);
 }
 
 static int	execute_builtin(char *cmds[], t_env *env)
@@ -67,7 +67,7 @@ static int	execute_executable(char *const argv[], t_env *env)
 	else
 	{
 		set_signal(3);
-		wait_child(pid, env);
+		status = wait_child(pid, env);
 	}
 	return (status);
 }


### PR DESCRIPTION
mallocのエラー処理が抜けていたので追加しました
追記：＄Aが展開できなかった時の終了ステータスの更新処理を追加しました
```
minishell$ $A
minishell$ $?
0: command not found
minishell$ " "
 : command not found
minishell$ $?
127: command not found
minishell$ $A
minishell$ $?
0: command not found
```
追記：パイプの終了ステータスを修正しました
```
minishell$ ls | cat | grep aaaaaa
minishell$ $?
1: command not found
```