### PR TITLE
fix: handle "cat << $A"

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/19 19:00:33 by kudoutomoya       #+#    #+#             */
-/*   Updated: 2023/11/20 09:45:34 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/22 09:21:57 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@
 
 int		execute(t_node *ast, t_env *env);
 int		execute_command(t_node *ast, t_env *env);
+int		parse_file(t_node *node, char **file_here);
 int		execute_redirect(t_node *ast, int fd[4], char **tmp_file);
 int		launch_command(char *const argv[], t_env *env);
 void	puterr(const char *input, const char *msg);
@@ -40,5 +41,6 @@ char	**make_argument_list(t_node *ast, t_env *env);
 void	restore_stdfd(int fd[4]);
 void	ft_unlink(char *file);
 void	free_matrix(char **matrix);
+int		free_retint(void *content, int retnum);
 
 #endif

--- a/srcs/execute/execute_redirect.c
+++ b/srcs/execute/execute_redirect.c
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/18 10:32:45 by ktomoya           #+#    #+#             */
-/*   Updated: 2023/11/20 12:48:22 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/22 08:33:50 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,11 +21,15 @@ int	free_retint(void *content, int retnum)
 
 int	parse_file(t_node *node, char **file_here)
 {
-	if (node->expand_flag == FAILURE && ft_memchr(node->str, '$', node->len))
+	if (node->expand_flag == FAILURE
+		&& ft_memchr(node->str, '$', node->len)
+		&& node->kind != NODE_DLESS)
 	{
 		puterr_len(node->str, node->len, "ambiguous redirect");
 		return (ERROR);
 	}
+	else if (node->expand_flag == FAILURE && node->kind == NODE_DLESS)
+		*file_here = ft_substr(node->str, 0, node->len);
 	else if (node->expand_flag == FAILURE)
 	{
 		*file_here = NULL;

--- a/srcs/pipe.c
+++ b/srcs/pipe.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pipe.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: smizuoch <smizuoch@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/24 16:09:28 by smizuoch          #+#    #+#             */
-/*   Updated: 2023/11/21 14:49:59 by smizuoch         ###   ########.fr       */
+/*   Updated: 2023/11/22 12:26:57 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,19 +55,131 @@ void	free_pipenode(t_pipe *a_pipe)
 	}
 }
 
+// int	execute_pipe_command(t_node *ast, t_env *env, char *tmp_file)
+
+int	srch_here_exec(t_node *nd, t_env *env, char **tmp_file)
+{
+	char	*here_end;
+
+	here_end = NULL;
+	if (!nd)
+		return (SUCCESS);
+	if (expect_node(nd, NODE_PIPE))
+	{
+		if (srch_here_exec(nd->left, env, tmp_file) == ERROR)
+			return (ERROR);
+		if (srch_here_exec(nd->right, env, tmp_file) == ERROR)
+			return (ERROR);
+		return (SUCCESS);
+	}
+	if (expect_node(nd, NODE_DLESS))
+	{
+		ft_unlink(*tmp_file);
+		if (parse_file(nd, &here_end) == ERROR)
+			return (ERROR);
+		*tmp_file = here_document(here_end);
+		free(here_end);
+	}
+	return (srch_here_exec(nd->right, env, tmp_file));
+}
+
+int	parse_redirect_file(t_node *nd, char **file)
+{
+	if (nd->expand_flag == FAILURE
+		&& ft_memchr(nd->str, '$', nd->len)
+		&& nd->kind != NODE_DLESS)
+	{
+		puterr_len(nd->str, nd->len, "ambiguous redirect");
+		return (ERROR);
+	}
+	else if (nd->expand_flag == FAILURE)
+	{
+		*file = NULL;
+		return (FAILURE);
+	}
+	else if (nd->expand)
+		*file = ft_substr(nd->expand, 0, ft_strlen(nd->expand));
+	else
+		*file = ft_substr(nd->str, 0, nd->len);
+	if (!*file)
+		return (putsyserr_retint("malloc", ERROR));
+	return (SUCCESS);
+}
+
+int	exec_pipe_redirect(t_node *nd, int fd[4], char *tmp_file)
+{
+	char	*file;
+	int		heredoc_flag;
+
+	heredoc_flag = 0;
+	while (expect_command(nd))
+	{
+		if (consume_right(&nd, NODE_ARGUMENT))
+			continue ;
+		if (parse_file(nd, &file) == ERROR)
+			return (ERROR);
+		if (nd->kind == NODE_LESS && redirect_input(file, fd) == ERROR)
+			return (free_retint(file, ERROR));
+		else if (nd->kind == NODE_GREAT && redirect_output(file, fd) == ERROR)
+			return (free_retint(file, ERROR));
+		else if (nd->kind == NODE_DGREAT && redirect_append(file, fd) == ERROR)
+			return (free_retint(file, ERROR));
+		else if (nd->kind == NODE_DLESS && heredoc_flag == 0)
+		{
+			if (fd[0] != fd[1])
+				restore_fd(fd[0], fd[1]);
+			if (redirect_input(tmp_file, fd) == ERROR)
+				return (ERROR);
+			heredoc_flag = 1;
+		}
+		free(file);
+		nd = nd->right;
+	}
+	return (SUCCESS);
+}
+
+int	execute_pipe_command(t_node *ast, t_env *env, char *tmp_file)
+{
+	int		fd[4];
+	int		status;
+	char	**args;
+
+	ft_memset(fd, 0, 4 * sizeof(int));
+	status = 0;
+	if (exec_pipe_redirect(ast, fd, tmp_file) == ERROR)
+	{
+		env->exit_status = 1;
+		restore_stdfd(fd);
+		return (1);
+	}
+	args = make_argument_list(ast, env);
+	if (args)
+	{
+		status = launch_command(args, env);
+		free_matrix(args);
+	}
+	restore_stdfd(fd);
+	return (status);
+}
+
 int	pipe_cmd(t_node *ast, t_env *env)
 {
 	int			status;
 	t_pipe		a_pipe;
 	t_pipenode	*tmp;
+	char		*tmp_file;
 
 	a_pipe.top = NULL;
 	a_pipe.save_fd = dup(0);
+	tmp_file = NULL;
 	while (ast->kind == NODE_PIPE)
 	{
 		tmp = new_pipenode(&a_pipe);
 		if (pipe(tmp->fd) < 0)
 			putsyserr_exit("pipe");
+		srch_here_exec(ast, env, &tmp_file);
+		if (g_signal == 2)
+			return (ERROR);
 		if ((tmp->pid = fork()) == 0)
 		{
 			set_signal(1);
@@ -75,7 +187,7 @@ int	pipe_cmd(t_node *ast, t_env *env)
 			dup2(tmp->fd[1], STDOUT_FILENO);
 			close(tmp->fd[0]);
 			close(tmp->fd[1]);
-			execute_command(ast->left, env);
+			execute_pipe_command(ast->left, env, tmp_file);
 			exit(0);
 		}
 		else if (tmp->pid == -1)
@@ -95,7 +207,7 @@ int	pipe_cmd(t_node *ast, t_env *env)
 			{
 				set_signal(1);
 				env->pipe_fd = 1;
-				status = execute_command(ast, env);
+				status = execute_pipe_command(ast, env, tmp_file);
 				exit(status);
 			}
 			else if (tmp->pid == -1)
@@ -116,7 +228,10 @@ int	pipe_cmd(t_node *ast, t_env *env)
 	}
 	waitpid(tmp->pid, &status, 0);
 	if (WIFEXITED(status))
+	{
 		env->exit_status = WEXITSTATUS(status);
+		ft_unlink(tmp_file);
+	}
 	else if (WIFSIGNALED(status))
 	{
 		write (1, "\n", 1);


### PR DESCRIPTION
以下のように$Aが展開できなかった時にヒアドキュメントの場合でも"ambiguous redirect"が出ていたので、修正しました
```
minishell$ ls << "$AAA"
"$AAA": ambiguous redirect
```