### PR TITLE
fix: modified "" expansion

### DIFF
--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/19 19:03:27 by kudoutomoya       #+#    #+#             */
-/*   Updated: 2023/11/20 09:59:48 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/25 08:23:39 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,32 +19,21 @@
 size_t	count_args(t_node *ast, t_env *env)
 {
 	size_t	count;
-	int		exist_expandable;
 
 	count = 0;
-	exist_expandable = 0;
 	while (ast && ast->kind != NODE_PIPE)
 	{
 		if (ast->kind == NODE_ARGUMENT && ast->expand_flag == SUCCESS)
 			count++;
-		else if (ast->kind == NODE_ARGUMENT && ast->expand_flag == FAILURE
-			&& !ft_strchr(ast->str, '$'))
-			exist_expandable = 1;
 		ast = ast->right;
 	}
-	if (count == 0 && exist_expandable == 1)
-	{
-		puterr(" ", "command not found");
-		env->exit_status = 127;
-	}
-	else if (count == 0)
+	if (count == 0)
 		env->exit_status = 0;
 	return (count);
 }
 
 int	get_arg(char **dst, t_node *node, char **head)
 {
-	(void)head;
 	if (node->expand)
 		*dst = ft_substr(node->expand, 0, ft_strlen(node->expand));
 	else

--- a/srcs/execute/execute_path.c
+++ b/srcs/execute/execute_path.c
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/14 14:14:21 by kudoutomoya       #+#    #+#             */
-/*   Updated: 2023/11/08 12:37:24 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/25 08:10:41 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,8 @@ void	search_path(char *const argv[], t_env *env)
 	char	file_path[PATH_MAX];
 	char	*dir;
 
+	if (argv[0][0] == '\0')
+		puterr_exit(argv[0], "command not found", 127);
 	dir_set = get_path_value(argv, env);
 	dir = ft_strtok(dir_set, ":");
 	while (dir)

--- a/srcs/expansion/expand.c
+++ b/srcs/expansion/expand.c
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/16 09:18:09 by ktomoya           #+#    #+#             */
-/*   Updated: 2023/11/21 13:22:06 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/25 07:53:31 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ int	expand_node(t_node *node, t_env *env)
 	if (!unexpand)
 		return (ERROR);
 	len = count_len(unexpand, env);
-	if (len == 0)
+	if (len == 0 && ft_strchr(node->str, '$'))
 	{
 		node->expand_flag = FAILURE;
 		free(unexpand);


### PR DESCRIPTION
```
minishell$ exit ""
exit
exit: : numeric argument required
➜  minishell git:(ktomoya) ✗ $?
zsh: command not found: 255
```