### PR TITLE
fix: add confirmation for flag error

### DIFF
--- a/srcs/parser/grammar.c
+++ b/srcs/parser/grammar.c
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/16 22:16:56 by kudoutomoya       #+#    #+#             */
-/*   Updated: 2023/11/16 08:44:44 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/29 15:14:13 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,8 @@ t_node	*command(t_token *tok, int *flag)
 	t_node	*list;
 	t_node	*node;
 
+	if (expect(TYPE_EOF, tok) || *flag == ERROR)
+		return (NULL);
 	if (expect(TYPE_PIPE, tok) || expect(TYPE_EOF, tok))
 	{
 		*flag = ERROR;

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/07 18:48:39 by ktomoya           #+#    #+#             */
-/*   Updated: 2023/11/16 08:41:13 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/29 15:23:16 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ t_node	*command_line(t_token *tok, int *flag)
 	node = command(tok, flag);
 	if (!node)
 		return (NULL);
-	if (consume(TYPE_PIPE, tok))
+	if (consume(TYPE_PIPE, tok) && *flag != ERROR)
 	{
 		if (expect(TYPE_EOF, tok) || expect(TYPE_PIPE, tok))
 		{


### PR DESCRIPTION
```
minishell$ a >|
syntax error near unexpected token `|'
syntax error near unexpected token `newline'
```
以上のエラーを直しました。