### PR TITLE
fix: change from using env->exit_status to status

### DIFF
--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/19 19:03:27 by kudoutomoya       #+#    #+#             */
-/*   Updated: 2023/11/29 10:28:39 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/29 15:59:19 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,9 +84,9 @@ int	execute_command(t_node *ast, t_env *env)
 	status = 0;
 	if (execute_redirect(ast, fd) == ERROR)
 	{
-		env->exit_status = 1;
+		status = 1;
 		restore_stdfd(fd);
-		return (1);
+		return (status);
 	}
 	args = make_argument_list(ast, env);
 	if (args)
@@ -100,16 +100,13 @@ int	execute_command(t_node *ast, t_env *env)
 
 int	execute(t_node *ast, t_env *env)
 {
-	int	status;
-
 	if (expect_node(ast, NODE_PIPE))
 		pipe_cmd(ast, env);
 	else
 	{
-		status = execute_command(ast, env);
+		env->exit_status = execute_command(ast, env);
 		if (g_signal == 2)
 			g_signal = 0;
-		return (status);
 	}
 	return (SUCCESS);
 }

--- a/srcs/execute/launch_command.c
+++ b/srcs/execute/launch_command.c
@@ -6,27 +6,27 @@
 /*   By: ktomoya <ktomoya@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/18 10:38:22 by ktomoya           #+#    #+#             */
-/*   Updated: 2023/11/20 14:52:49 by ktomoya          ###   ########.fr       */
+/*   Updated: 2023/11/29 16:04:37 by ktomoya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/execute.h"
 #include "../../includes/minishell.h"
 
-static int	wait_child(pid_t pid, t_env *env)
+static int	wait_child(pid_t pid)
 {
 	int	status;
 
 	if (wait(&status) != pid)
 		putsyserr_exit("wait");
 	if (WIFEXITED(status))
-		env->exit_status = WEXITSTATUS(status);
+		status = WEXITSTATUS(status);
 	else if (WIFSIGNALED(status))
 	{
 		write(1, "\n", 1);
-		env->exit_status = WTERMSIG(status) + 128;
+		status = WTERMSIG(status) + 128;
 	}
-	return (env->exit_status);
+	return (status);
 }
 
 static int	execute_builtin(char *cmds[], t_env *env)
@@ -67,7 +67,7 @@ static int	execute_executable(char *const argv[], t_env *env)
 	else
 	{
 		set_signal(3);
-		status = wait_child(pid, env);
+		status = wait_child(pid);
 	}
 	return (status);
 }
@@ -75,10 +75,7 @@ static int	execute_executable(char *const argv[], t_env *env)
 int	launch_command(char *const argv[], t_env *env)
 {
 	if (is_builtin(argv[0]))
-	{
-		env->exit_status = execute_builtin((char **)argv, env);
-		return (0);
-	}
+		return (execute_builtin((char **)argv, env));
 	else
 		return (execute_executable(argv, env));
 }


### PR DESCRIPTION
以下の状況に対応しました

```
bash-3.2$ exit | exit 1 a
bash: exit: too many arguments
bash-3.2$ $?
bash: 1: command not found
```